### PR TITLE
Fix return types for Contains methods

### DIFF
--- a/Tests/EditorTests/Tests.PlaylistEntryCollectionMock.cs
+++ b/Tests/EditorTests/Tests.PlaylistEntryCollectionMock.cs
@@ -12,8 +12,8 @@ public partial class Tests {
 
     public void Add(IPlaylistEntry entry) => throw new NotImplementedException();
     public void Clear() => throw new NotImplementedException();
-    public void ContainsByHash(string hash) => throw new NotImplementedException();
-    public void ContainsByName(string name) => throw new NotImplementedException();
+    public bool ContainsByHash(string hash) => throw new NotImplementedException();
+    public bool ContainsByName(string name) => throw new NotImplementedException();
     public IEnumerator<IPlaylistEntry> GetEnumerator() => this._entries.GetEnumerator();
     public void InsertAt(int index, IPlaylistEntry entry) => throw new NotImplementedException();
     public void RemoveAt(int index) => throw new NotImplementedException();

--- a/src/BeatSaber API/BeatSaber.PlaylistEntryCollection.cs
+++ b/src/BeatSaber API/BeatSaber.PlaylistEntryCollection.cs
@@ -16,8 +16,8 @@ partial class BeatSaberInstallation {
     public void InsertAt(int index, IPlaylistEntry entry) => this._entries.Insert(index, entry);
     public void RemoveAt(int index) => this._entries.RemoveAt(index);
     public void Clear() => this._entries.Clear();
-    public void ContainsByName(string name) => this._entries.Any(i => i.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-    public void ContainsByHash(string hash) => this._entries.Any(i => i.Sha1Hash.Equals(hash, StringComparison.OrdinalIgnoreCase));
+    public bool ContainsByName(string name) => this._entries.Any(i => i.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    public bool ContainsByHash(string hash) => this._entries.Any(i => i.Sha1Hash.Equals(hash, StringComparison.OrdinalIgnoreCase));
 
   }
 

--- a/src/BeatSaber API/IPlaylistEntryCollection.cs
+++ b/src/BeatSaber API/IPlaylistEntryCollection.cs
@@ -3,8 +3,8 @@
 public interface IPlaylistEntryCollection : IEnumerable<IPlaylistEntry> {
   void Add(IPlaylistEntry entry);
   void Clear();
-  void ContainsByHash(string hash);
-  void ContainsByName(string name);
+  bool ContainsByHash(string hash);
+  bool ContainsByName(string name);
   void InsertAt(int index, IPlaylistEntry entry);
   void RemoveAt(int index);
 }


### PR DESCRIPTION
## Summary
- make `ContainsByName` and `ContainsByHash` return `bool`
- update PlaylistEntryCollection implementation
- adjust editor test mock

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684158bade448333b7b3c69f057bd391