### PR TITLE
Add playlist description property

### DIFF
--- a/src/BeatSaber API/BeatSaber.Playlist.cs
+++ b/src/BeatSaber API/BeatSaber.Playlist.cs
@@ -34,6 +34,11 @@ partial class BeatSaberInstallation {
       set => this._Data.PlaylistAuthor = value;
     }
 
+    public string? Description {
+      get => this._Data.PlaylistDescription;
+      set => this._Data.PlaylistDescription = value;
+    }
+
     public IPlaylistEntryCollection Songs => this._entries.Value;
 
     public Image? Image {

--- a/src/BeatSaber API/IPlaylist.cs
+++ b/src/BeatSaber API/IPlaylist.cs
@@ -5,6 +5,7 @@ namespace BeatSaberAPI;
 public interface IPlaylist { 
   string Name { get; set; }
   string? Author { get; set; }
+  string? Description { get; set; }
   Image? Image { get; }
   IPlaylistEntryCollection Songs { get; }
   IPlaylistEntry CreateEntry(ISong song, string? displayName = null);

--- a/src/BeatSaber Playlist Editor/MainForm.Designer.cs
+++ b/src/BeatSaber Playlist Editor/MainForm.Designer.cs
@@ -50,6 +50,8 @@ partial class MainForm : Form {
       System.Windows.Forms.Label lPlaylistName;
       System.Windows.Forms.Label lPlaylistAuthor;
       System.Windows.Forms.TextBox tbPlaylistAuthor;
+      System.Windows.Forms.Label lPlaylistDescription;
+      System.Windows.Forms.TextBox tbPlaylistDescription;
       System.Windows.Forms.SplitContainer splitContainer3;
       System.Windows.Forms.ToolStrip tsSongs;
       System.Windows.Forms.ToolStripLabel tslFilter;
@@ -106,6 +108,8 @@ partial class MainForm : Form {
       lPlaylistName = new System.Windows.Forms.Label();
       lPlaylistAuthor = new System.Windows.Forms.Label();
       tbPlaylistAuthor = new System.Windows.Forms.TextBox();
+      lPlaylistDescription = new System.Windows.Forms.Label();
+      tbPlaylistDescription = new System.Windows.Forms.TextBox();
       splitContainer3 = new System.Windows.Forms.SplitContainer();
       tsSongs = new System.Windows.Forms.ToolStrip();
       tslFilter = new System.Windows.Forms.ToolStripLabel();
@@ -452,6 +456,8 @@ partial class MainForm : Form {
       tlpPlaylistProperties.Controls.Add(lPlaylistAuthor, 0, 3);
       tlpPlaylistProperties.Controls.Add(this.tbPlaylistName, 1, 2);
       tlpPlaylistProperties.Controls.Add(tbPlaylistAuthor, 1, 3);
+      tlpPlaylistProperties.Controls.Add(lPlaylistDescription, 0, 4);
+      tlpPlaylistProperties.Controls.Add(tbPlaylistDescription, 1, 4);
       tlpPlaylistProperties.Dock = System.Windows.Forms.DockStyle.Fill;
       tlpPlaylistProperties.Location = new System.Drawing.Point(3, 19);
       tlpPlaylistProperties.Name = "tlpPlaylistProperties";
@@ -460,7 +466,7 @@ partial class MainForm : Form {
       tlpPlaylistProperties.RowStyles.Add(new System.Windows.Forms.RowStyle());
       tlpPlaylistProperties.RowStyles.Add(new System.Windows.Forms.RowStyle());
       tlpPlaylistProperties.RowStyles.Add(new System.Windows.Forms.RowStyle());
-      tlpPlaylistProperties.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+      tlpPlaylistProperties.RowStyles.Add(new System.Windows.Forms.RowStyle());
       tlpPlaylistProperties.Size = new System.Drawing.Size(233, 177);
       tlpPlaylistProperties.TabIndex = 0;
       // 
@@ -513,9 +519,9 @@ partial class MainForm : Form {
       lPlaylistAuthor.Size = new System.Drawing.Size(44, 15);
       lPlaylistAuthor.TabIndex = 2;
       lPlaylistAuthor.Text = "Author";
-      // 
+      //
       // tbPlaylistName
-      // 
+      //
       this.tbPlaylistName.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.bsViewModel, "CurrentPlaylistName", true));
       this.tbPlaylistName.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.bsViewModel, "IsCurrentPlaylistAvailable", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
       this.tbPlaylistName.Dock = System.Windows.Forms.DockStyle.Top;
@@ -534,6 +540,26 @@ partial class MainForm : Form {
       tbPlaylistAuthor.Name = "tbPlaylistAuthor";
       tbPlaylistAuthor.Size = new System.Drawing.Size(177, 23);
       tbPlaylistAuthor.TabIndex = 4;
+      //
+      // lPlaylistDescription
+      //
+      lPlaylistDescription.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      lPlaylistDescription.AutoSize = true;
+      lPlaylistDescription.Location = new System.Drawing.Point(3, 164);
+      lPlaylistDescription.Name = "lPlaylistDescription";
+      lPlaylistDescription.Size = new System.Drawing.Size(67, 15);
+      lPlaylistDescription.TabIndex = 2;
+      lPlaylistDescription.Text = "Description";
+      //
+      // tbPlaylistDescription
+      //
+      tbPlaylistDescription.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.bsViewModel, "CurrentPlaylistDescription", true));
+      tbPlaylistDescription.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.bsViewModel, "IsCurrentPlaylistAvailable", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+      tbPlaylistDescription.Dock = System.Windows.Forms.DockStyle.Top;
+      tbPlaylistDescription.Location = new System.Drawing.Point(53, 160);
+      tbPlaylistDescription.Name = "tbPlaylistDescription";
+      tbPlaylistDescription.Size = new System.Drawing.Size(177, 23);
+      tbPlaylistDescription.TabIndex = 5;
       // 
       // splitContainer3
       // 

--- a/src/BeatSaber Playlist Editor/ViewModel/UIMain.UIPlaylist.cs
+++ b/src/BeatSaber Playlist Editor/ViewModel/UIMain.UIPlaylist.cs
@@ -18,6 +18,17 @@ partial class UIMain {
 
     public string Name => this.Source.Name;
     public string? Author => this.Source.Author;
+    public string? Description
+    {
+      get => this.Source.Description;
+      set
+      {
+        if (value == this.Source.Description)
+          return;
+        this.Source.Description = value;
+        this._OnPropertyChanged();
+      }
+    }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public string CoverDetails => this._cover.Value == null ? "No image" : $"{this.Cover.Width} x {this.Cover.Height}";
@@ -45,6 +56,7 @@ partial class UIMain {
     public void TriggerAllPropertiesChanged() {
       this._OnPropertyChanged(nameof(Name));
       this._OnPropertyChanged(nameof(Author));
+      this._OnPropertyChanged(nameof(Description));
       this._OnPropertyChanged(nameof(Cover));
       this._OnPropertyChanged(nameof(CoverDetails));
     }

--- a/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
+++ b/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
@@ -98,6 +98,14 @@ internal partial class UIMain : INotifyPropertyChanged {
     }
   } = string.Empty;
 
+  public string? CurrentPlaylistDescription {
+    get => field;
+    set {
+      if (this.SetProperty(this.OnPropertyChanged, ref field, value))
+        this._MarkCurrentPlaylistModified();
+    }
+  } = string.Empty;
+
   public IBeatSaberInstallation? BeatSaber {
     get => field;
     private set {
@@ -193,6 +201,7 @@ internal partial class UIMain : INotifyPropertyChanged {
 
     cp.Source.Name = this.CurrentPlaylistName;
     cp.Source.Author = this.CurrentPlaylistAuthor;
+    cp.Source.Description = this.CurrentPlaylistDescription;
     cp.Source.Songs.Clear();
     foreach (var entry in this.CurrentPlaylistEntries)
       cp.Source.Songs.Add(entry.Source);
@@ -219,6 +228,7 @@ internal partial class UIMain : INotifyPropertyChanged {
     this.IsCurrentPlaylistAvailable = cp != null;
     this.CurrentPlaylistAuthor = cp?.Author ?? string.Empty;
     this.CurrentPlaylistName= cp?.Name??string.Empty;
+    this.CurrentPlaylistDescription = cp?.Description;
     this._MarkCurrentPlaylistUnmodified();
   }
 


### PR DESCRIPTION
## Summary
- expose `Description` on `IPlaylist` and implement it in `BeatSaber.Playlist`
- add `Description` property to `UIPlaylist`
- support editing playlist descriptions through `UIMain`
- add a `Description` text box in `MainForm`

## Testing
- `dotnet test` *(fails: project references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68417f8b4e5083339bf04b1c58e7624a