### PR TITLE
Fix moving order for multi selection

### DIFF
--- a/Tests/EditorTests/UnitTest.cs
+++ b/Tests/EditorTests/UnitTest.cs
@@ -52,5 +52,23 @@ public partial class Tests {
     CollectionAssert.AreEqual(new[] { b, c, a }, vm.CurrentPlaylistEntries);
   }
 
+  [Test]
+  public void TestMultiUpOrdering() {
+    var vm = CreateVM(out var a, out var b, out var c);
+
+    vm.MoveUp(new[] { c, b });
+
+    CollectionAssert.AreEqual(new[] { b, c, a }, vm.CurrentPlaylistEntries);
+  }
+
+  [Test]
+  public void TestMultiDownOrdering() {
+    var vm = CreateVM(out var a, out var b, out var c);
+
+    vm.MoveDown(new[] { b, a });
+
+    CollectionAssert.AreEqual(new[] { c, a, b }, vm.CurrentPlaylistEntries);
+  }
+
 
 }

--- a/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
+++ b/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
@@ -251,10 +251,9 @@ internal partial class UIMain : INotifyPropertyChanged {
   }
 
   public void MoveUp(IEnumerable<UIPlaylistEntry> entries) {
-    // TODO: fix when moving more than one
     var currentPlaylistEntries = this.CurrentPlaylistEntries;
 
-    foreach (var entry in entries.Reverse()) {
+    foreach (var entry in entries.OrderBy(e => currentPlaylistEntries.IndexOf(e))) {
       var oldPosition = currentPlaylistEntries.IndexOf(entry);
       if (oldPosition <= 0)
         continue;
@@ -281,11 +280,10 @@ internal partial class UIMain : INotifyPropertyChanged {
   }
 
   public void MoveDown(IEnumerable<UIPlaylistEntry> entries) {
-    // TODO: fix when moving more than one
     var currentPlaylistEntries = this.CurrentPlaylistEntries;
     var length = currentPlaylistEntries.Count - 1;
 
-    foreach (var entry in entries) {
+    foreach (var entry in entries.OrderByDescending(e => currentPlaylistEntries.IndexOf(e))) {
       var oldPosition = currentPlaylistEntries.IndexOf(entry);
       if (oldPosition < 0 || oldPosition >= length)
         continue;


### PR DESCRIPTION
## Summary
- preserve relative ordering of selected items on MoveUp and MoveDown
- test moving multiple playlist entries

## Testing
- `dotnet test Tests/EditorTests/EditorTests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841819cf4f083339fed1fe7952d28a8