### PR TITLE
Insert songs at drop position

### DIFF
--- a/src/BeatSaber Playlist Editor/MainForm.cs
+++ b/src/BeatSaber Playlist Editor/MainForm.cs
@@ -1,6 +1,7 @@
 using BeatSaber_Playlist_Editor.ViewModel;
 using BeatSaberAPI;
 using static BeatSaber_Playlist_Editor.ViewModel.UIMain;
+using System.Drawing;
 
 namespace BeatSaber_Playlist_Editor;
 
@@ -120,8 +121,11 @@ internal partial class MainForm : Form {
         return;
       }
 
-      this._viewModel?.AppendSongs(songs);
-      // TODO: would be nice to know where drop occured and insert songs there if possible
+      var clientPoint = this.dgvPlaylistEntries.PointToClient(new Point(e.X, e.Y));
+      var hit = this.dgvPlaylistEntries.HitTest(clientPoint.X, clientPoint.Y);
+      var index = hit.RowIndex < 0 ? this.dgvPlaylistEntries.Rows.Count : hit.RowIndex;
+
+      this._viewModel?.InsertSongsAt(index, songs);
     }
 
     private void pbPlaylistCover_Click(object _, EventArgs __) {

--- a/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
+++ b/src/BeatSaber Playlist Editor/ViewModel/UIMain.cs
@@ -311,7 +311,7 @@ internal partial class UIMain : INotifyPropertyChanged {
     this._MarkCurrentPlaylistModified();
   }
 
-  public void AppendSongs(IEnumerable<UISong> songs) {
+  public void InsertSongsAt(int index, IEnumerable<UISong> songs) {
     var currentPlaylist = this.CurrentPlaylist;
     if (currentPlaylist == null)
       return;
@@ -319,11 +319,14 @@ internal partial class UIMain : INotifyPropertyChanged {
     var currentPlaylistEntries = this.CurrentPlaylistEntries;
     foreach (var song in songs) {
       var entry = currentPlaylist.Source.CreateEntry(song.Source);
-      currentPlaylistEntries.Add(new UIPlaylistEntry(entry));
+      currentPlaylistEntries.Insert(index++, new UIPlaylistEntry(entry));
     }
 
     this._MarkCurrentPlaylistModified();
   }
+
+  public void AppendSongs(IEnumerable<UISong> songs)
+    => this.InsertSongsAt(this.CurrentPlaylistEntries.Count, songs);
 
   public void SetPlaylistCover(FileInfo file) {
     var currentPlaylist = this.CurrentPlaylist;


### PR DESCRIPTION
## Summary
- detect drop row in playlist
- add `InsertSongsAt` to allow inserting songs at specific index
- update drag-drop handler to use `InsertSongsAt`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841847812e08333a2b3ff60236ca0b2