### PR TITLE
Fix drawing extensions reference

### DIFF
--- a/BeatSaber Playlist Editor.sln
+++ b/BeatSaber Playlist Editor.sln
@@ -5,19 +5,11 @@ VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BeatSaber Playlist Editor", "src\BeatSaber Playlist Editor\BeatSaber Playlist Editor.csproj", "{103DDCD9-F55A-48E8-AB63-8C3E401F5976}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Corlib.Extensions", "..\..\Framework\Corlib.Extensions\Corlib.Extensions.csproj", "{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Backports", "..\..\Framework\Backports\Backports.csproj", "{486726AB-541C-4AF7-AD13-D5350F23C471}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BeatSaber API", "src\BeatSaber API\BeatSaber API.csproj", "{6CD95798-50DF-4120-B0E8-09890DC7F812}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{1E79AFBF-52F1-42A4-B62F-C83F62A838B8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Form.Extensions", "..\..\Framework\System.Windows.Forms.Extensions\System.Windows.Form.Extensions.csproj", "{CDCF6FC9-F8FE-4441-95C4-FB675EE30723}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EditorTests", "Tests\EditorTests\EditorTests.csproj", "{902460CD-A95F-4516-8459-4E44C0557131}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Drawing.Extensions", "..\..\Framework\System.Drawing.Extensions\System.Drawing.Extensions.csproj", "{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,39 +21,17 @@ Global
 		{103DDCD9-F55A-48E8-AB63-8C3E401F5976}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{103DDCD9-F55A-48E8-AB63-8C3E401F5976}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{103DDCD9-F55A-48E8-AB63-8C3E401F5976}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421}.Release|Any CPU.Build.0 = Release|Any CPU
-		{486726AB-541C-4AF7-AD13-D5350F23C471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{486726AB-541C-4AF7-AD13-D5350F23C471}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{486726AB-541C-4AF7-AD13-D5350F23C471}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{486726AB-541C-4AF7-AD13-D5350F23C471}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6CD95798-50DF-4120-B0E8-09890DC7F812}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6CD95798-50DF-4120-B0E8-09890DC7F812}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CD95798-50DF-4120-B0E8-09890DC7F812}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CD95798-50DF-4120-B0E8-09890DC7F812}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CDCF6FC9-F8FE-4441-95C4-FB675EE30723}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CDCF6FC9-F8FE-4441-95C4-FB675EE30723}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CDCF6FC9-F8FE-4441-95C4-FB675EE30723}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CDCF6FC9-F8FE-4441-95C4-FB675EE30723}.Release|Any CPU.Build.0 = Release|Any CPU
 		{902460CD-A95F-4516-8459-4E44C0557131}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{902460CD-A95F-4516-8459-4E44C0557131}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{902460CD-A95F-4516-8459-4E44C0557131}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{902460CD-A95F-4516-8459-4E44C0557131}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{4D0F199E-CFC4-4A80-B9C9-604E9DBAA421} = {1E79AFBF-52F1-42A4-B62F-C83F62A838B8}
-		{486726AB-541C-4AF7-AD13-D5350F23C471} = {1E79AFBF-52F1-42A4-B62F-C83F62A838B8}
-		{CDCF6FC9-F8FE-4441-95C4-FB675EE30723} = {1E79AFBF-52F1-42A4-B62F-C83F62A838B8}
-		{D4A604EE-76BB-46EF-9E0A-3B7675EA5EA1} = {1E79AFBF-52F1-42A4-B62F-C83F62A838B8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {61D088B0-DF24-4502-8346-2BC783EF38AB}

--- a/src/BeatSaber API/BeatSaber API.csproj
+++ b/src/BeatSaber API/BeatSaber API.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="FrameworkExtensions.Corlib" Version="1.0.2.480" />
-    <ProjectReference Include="..\..\..\..\Framework\System.Drawing.Extensions\System.Drawing.Extensions.csproj" />
+    <PackageReference Include="FrameworkExtensions.System.Drawing" Version="1.0.0.36" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- use the `FrameworkExtensions.System.Drawing` NuGet package
- remove obsolete project from the solution
- remove remaining Corlib, Backports, and WinForm extension projects from the solution

## Testing
- `dotnet restore "src/BeatSaber Playlist Editor/BeatSaber Playlist Editor.csproj"`
- `dotnet restore "Tests/EditorTests/EditorTests.csproj"`
- `dotnet test Tests/EditorTests/EditorTests.csproj -c Release` *(fails: Only auto-implemented properties, or properties that use the 'field' keyword, can have initializers.)*

------
https://chatgpt.com/codex/tasks/task_e_6841a67ce66c8333b304228c0f4cdf40